### PR TITLE
I18n compatible exception emission (Issue #8)

### DIFF
--- a/lib/r18n-rails-api/backend.rb
+++ b/lib/r18n-rails-api/backend.rb
@@ -61,7 +61,7 @@ module R18n
           end
         end
 
-        raise ::I18n::MissingTranslationData.new(locale, key, options)
+        throw :exception, ::I18n::MissingTranslationData.new(locale, key, options)
       else
         result
       end


### PR DESCRIPTION
To `throw` when the translation is missing instead of `raise`, that can be `catch`ed by `I18n::Base`.